### PR TITLE
Quick and dirty job name expansion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 		<version>2.1.0</version> <relativePath>../pom.xml</relativePath> </parent -->
 
 	<artifactId>jenkins-multijob-plugin</artifactId>
-	<version>1.32-SNAPSHOT</version>
+	<version>1.32-hbo-1</version>
 	<name>Jenkins Multijob plugin</name>
 	<description>Enabling full hierarchy of Jenkins jobs</description>
 	<url>http://wiki.jenkins-ci.org/display/JENKINS/Multijob+Plugin</url>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -268,7 +268,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         final CounterManager phaseCounters = new CounterManager();
         boolean aggragatedTestResults = false;
         for (PhaseJobsConfig phaseJobConfig : phaseJobs) {
-            Item item = jenkins.getItem(phaseJobConfig.getJobName(), multiJobBuild.getParent(), AbstractProject.class);
+            String resolvedJobName = expandToken(phaseJobConfig.getJobName(), build, listener);
+            Item item = jenkins.getItem(resolvedJobName, multiJobBuild.getParent(), AbstractProject.class);
             if (item instanceof AbstractProject) {
                 AbstractProject job = (AbstractProject) item;
                 phaseSubJobs.put(new PhaseSubJob(job), phaseJobConfig);
@@ -277,7 +278,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 aggragatedTestResults = true;
             }
         }
-        
+
         if (aggragatedTestResults) {
             multiJobBuild.addTestsResult();
         }

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -209,7 +209,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 				disableJob, enableRetryStrategy, parsingRulesPath, maxRetries, enableCondition,
 				abortAllJob, condition, buildOnlyIfSCMChanges, applyConditionOnlyIfNoSCMChanges, false);
         }
-        
+
 	@DataBoundConstructor
 	public PhaseJobsConfig(String jobName, String jobAlias, String jobProperties,
 			boolean currParams, List<AbstractBuildParameters> configs,


### PR DESCRIPTION
### GOAL

Allow the "Job Name" of a phased subjob to use variable expansion.

### CHANGES

- Tiny hack (add token macro support for the job name field when instantiating the phase subjob build).  Currently no real tests or other changes.